### PR TITLE
Add page create/copy client methods

### DIFF
--- a/.changeset/page-lifecycle-create-copy.md
+++ b/.changeset/page-lifecycle-create-copy.md
@@ -1,0 +1,5 @@
+---
+"@flexbe/sdk": minor
+---
+
+Add page create/copy/from-ai client methods (global via createPage type)

--- a/src/client/pages.ts
+++ b/src/client/pages.ts
@@ -1,5 +1,27 @@
 import { ApiClient } from './api-client';
-import { BulkDeleteResponse, BulkUpdateFolderItem, BulkUpdateFolderResponse, BulkUpdatePageItem, BulkUpdateResponse, CreateFolderParams, CreatePageVersionParams, GetPagesParams, Page, PageFolder, PageFolderListResponse, PageListResponse, PageVersionDataResponse, PageVersionListResponse, UpdateFolderParams, UpdatePageParams } from '../types/pages';
+import {
+    BulkDeleteResponse,
+    BulkUpdateFolderItem,
+    BulkUpdateFolderResponse,
+    BulkUpdatePageItem,
+    BulkUpdateResponse,
+    CopyPageParams,
+    CopyPagesParams,
+    CopyPagesResponse,
+    CreateFolderParams,
+    CreatePageFromAiParams,
+    CreatePageParams,
+    CreatePageVersionParams,
+    GetPagesParams,
+    Page,
+    PageFolder,
+    PageFolderListResponse,
+    PageListResponse,
+    PageVersionDataResponse,
+    PageVersionListResponse,
+    UpdateFolderParams,
+    UpdatePageParams,
+} from '../types/pages';
 
 export class Pages {
     constructor(
@@ -33,6 +55,42 @@ export class Pages {
             : undefined;
 
         const response = await this.api.get<PageListResponse>(`/sites/${ this.siteId }/pages`, { params: processedParams });
+
+        return response.data;
+    }
+
+    /**
+     * Create a page: clone from template/source, or pass `type: 'global'` with layout body
+     */
+    async createPage(data: CreatePageParams): Promise<Page> {
+        const response = await this.api.post<Page>(`/sites/${ this.siteId }/pages`, data);
+
+        return response.data;
+    }
+
+    /**
+     * Create a page from a completed AI generation
+     */
+    async createPageFromAi(data: CreatePageFromAiParams): Promise<Page> {
+        const response = await this.api.post<Page>(`/sites/${ this.siteId }/pages/from-ai`, data);
+
+        return response.data;
+    }
+
+    /**
+     * Copy a single page
+     */
+    async copyPage(pageId: number, data: CopyPageParams): Promise<Page> {
+        const response = await this.api.post<Page>(`/sites/${ this.siteId }/pages/${ pageId }/copy`, data);
+
+        return response.data;
+    }
+
+    /**
+     * Bulk-copy pages
+     */
+    async copyPages(data: CopyPagesParams): Promise<CopyPagesResponse> {
+        const response = await this.api.post<CopyPagesResponse>(`/sites/${ this.siteId }/pages/copy`, data);
 
         return response.data;
     }

--- a/src/types/pages.ts
+++ b/src/types/pages.ts
@@ -122,6 +122,43 @@ export interface UpdatePageParams {
     meta?: Partial<PageMeta>;
 }
 
+export interface CreatePageParams {
+    /** Omit/`page` = clone from template or source; `global` = inline layout payload */
+    type?: PageType.PAGE | PageType.GLOBAL;
+    templateId?: number;
+    sourcePageId?: number;
+    name?: string;
+    uri?: string;
+    folderId?: number | null;
+    themeId?: number | null;
+    is?: string;
+    template_id?: string;
+    blocks?: unknown[];
+    modals?: unknown[];
+    widgets?: unknown[];
+}
+
+export interface CreatePageFromAiParams {
+    pageUUID: string;
+}
+
+export interface CopyPageParams {
+    name: string;
+    uri?: string;
+    folderId?: number | null;
+    targetSiteId?: number;
+}
+
+export interface CopyPagesParams {
+    pageIds: number[];
+    folderId?: number | null;
+    targetSiteId?: number;
+}
+
+export interface CopyPagesResponse {
+    pages: Page[];
+}
+
 export interface CreatePageVersionParams {
     data: PageDataStructure;
     assets?: {

--- a/test/client/pages-lifecycle.test.ts
+++ b/test/client/pages-lifecycle.test.ts
@@ -1,0 +1,77 @@
+import { Pages } from '../../src/client/pages';
+
+import type { ApiClient } from '../../src/client/api-client';
+import type { Page } from '../../src/types/pages';
+
+describe('pages create/copy client', () => {
+    const siteId = 42;
+    const page: Page = {
+        id: 10,
+        versionId: 1,
+        editorVersionId: 1,
+        type: 'page' as Page['type'],
+        status: 'published' as Page['status'],
+        name: 'Page',
+        uri: '/page/',
+        language: 'en',
+        folderId: 0,
+        sortIndex: 10,
+        themeId: 4,
+        updatedAt: new Date().toISOString(),
+        deletedAt: null,
+        screenshot: null,
+        meta: null,
+    };
+
+    let api: { post: jest.Mock };
+    let pages: Pages;
+
+    beforeEach(() => {
+        api = {
+            post: jest.fn().mockResolvedValue({ data: page, status: 201, statusText: 'Created' }),
+        };
+        pages = new Pages(api as unknown as ApiClient, siteId);
+    });
+
+    it('createPage posts to /pages', async() => {
+        const body = { sourcePageId: 5, name: 'New', uri: '/new/' };
+        const result = await pages.createPage(body);
+
+        expect(result).toEqual(page);
+        expect(api.post).toHaveBeenCalledWith(`/sites/${ siteId }/pages`, body);
+    });
+
+    it('createPage with type global posts to /pages', async() => {
+        const body = { type: 'global' as const, blocks: [], modals: [], widgets: [] };
+
+        await pages.createPage(body);
+
+        expect(api.post).toHaveBeenCalledWith(`/sites/${ siteId }/pages`, body);
+    });
+
+    it('createPageFromAi posts to /pages/from-ai', async() => {
+        const body = { pageUUID: 'uuid-1' };
+
+        await pages.createPageFromAi(body);
+
+        expect(api.post).toHaveBeenCalledWith(`/sites/${ siteId }/pages/from-ai`, body);
+    });
+
+    it('copyPage posts to /pages/:id/copy', async() => {
+        const body = { name: 'Copy', uri: '/copy/' };
+
+        await pages.copyPage(9, body);
+
+        expect(api.post).toHaveBeenCalledWith(`/sites/${ siteId }/pages/9/copy`, body);
+    });
+
+    it('copyPages posts to /pages/copy', async() => {
+        api.post.mockResolvedValue({ data: { pages: [ page ] }, status: 201, statusText: 'Created' });
+
+        const body = { pageIds: [ 1, 2 ] };
+        const result = await pages.copyPages(body);
+
+        expect(result.pages).toHaveLength(1);
+        expect(api.post).toHaveBeenCalledWith(`/sites/${ siteId }/pages/copy`, body);
+    });
+});


### PR DESCRIPTION
Expose createPage (including type=global), createPageFromAi, copyPage, and copyPages for Nest page lifecycle routes.