### PR TITLE
Add site redirects client

### DIFF
--- a/.changeset/site-redirects-api.md
+++ b/.changeset/site-redirects-api.md
@@ -1,0 +1,5 @@
+---
+"@flexbe/sdk": minor
+---
+
+Add site redirects client (CRUD + replace by type) with public camelCase redirect types.

--- a/src/client/redirects.ts
+++ b/src/client/redirects.ts
@@ -1,0 +1,70 @@
+import type { ApiClient } from './api-client';
+import type {
+    CreateRedirectParams,
+    GetRedirectsParams,
+    Redirect,
+    RedirectKind,
+    RedirectListResponse,
+    ReplaceRedirectItem,
+    UpdateRedirectParams,
+} from '../types/redirects';
+
+export class Redirects {
+    constructor(
+        private readonly api: ApiClient,
+        private readonly siteId: number
+    ) {}
+
+    /** List redirects for a site. Optionally filter by type. */
+    async getRedirects(params?: GetRedirectsParams): Promise<RedirectListResponse> {
+        const response = await this.api.get<RedirectListResponse>(this.basePath(), { params });
+
+        return response.data;
+    }
+
+    /** Get a single redirect by ID. */
+    async getRedirect(redirectId: number): Promise<Redirect> {
+        const response = await this.api.get<Redirect>(this.basePath(`/${ redirectId }`));
+
+        return response.data;
+    }
+
+    /** Create a redirect. */
+    async createRedirect(body: CreateRedirectParams): Promise<Redirect> {
+        const response = await this.api.post<Redirect>(this.basePath(), body);
+
+        return response.data;
+    }
+
+    /** Patch a redirect. */
+    async updateRedirect(redirectId: number, patch: UpdateRedirectParams): Promise<Redirect> {
+        const response = await this.api.patch<Redirect>(this.basePath(`/${ redirectId }`), patch);
+
+        return response.data;
+    }
+
+    /** Delete a redirect. */
+    async deleteRedirect(redirectId: number): Promise<void> {
+        await this.api.delete(this.basePath(`/${ redirectId }`));
+    }
+
+    /**
+     * Replace all redirects of a type. Items without id are created;
+     * existing ids omitted from the list are deleted. Array order sets sortIndex.
+     */
+    async replaceRedirects(
+        type: RedirectKind,
+        items: ReplaceRedirectItem[]
+    ): Promise<RedirectListResponse> {
+        const response = await this.api.put<RedirectListResponse>(
+            this.basePath(`/${ type }`),
+            { items }
+        );
+
+        return response.data;
+    }
+
+    private basePath(suffix = ''): string {
+        return `/sites/${ this.siteId }/redirects${ suffix }`;
+    }
+}

--- a/src/client/site-api.ts
+++ b/src/client/site-api.ts
@@ -1,4 +1,5 @@
 import { Pages } from './pages';
+import { Redirects } from './redirects';
 import { Sandbox } from './sandbox';
 import { Stat } from './stat';
 
@@ -6,6 +7,7 @@ import type { ApiClient } from './api-client';
 
 export class SiteApi {
     public readonly pages: Pages;
+    public readonly redirects: Redirects;
     public readonly sandbox: Sandbox;
     public readonly stat: Stat;
 
@@ -14,6 +16,7 @@ export class SiteApi {
         siteId: number
     ) {
         this.pages = new Pages(api, siteId);
+        this.redirects = new Redirects(api, siteId);
         this.sandbox = new Sandbox(api, siteId);
         this.stat = new Stat(api, siteId);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './client/client';
 export * from './client/pages';
+export * from './client/redirects';
 export * from './client/sandbox';
 export * from './types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './meta';
 export * from './animations';
 export * from './pages';
+export * from './redirects';
 export * from './stat';
 export * from './sandbox';
 

--- a/src/types/redirects.ts
+++ b/src/types/redirects.ts
@@ -1,0 +1,57 @@
+export type RedirectKind = 'standard' | 'geo';
+export type RedirectTypeCode = 301 | 302 | 200;
+
+export type RedirectCondition = {
+    enabled: boolean;
+    exclude: boolean;
+    list: string[];
+};
+
+type RedirectWritableFields = {
+    enabled?: boolean;
+    fromAllPages?: boolean;
+    regularFromPage?: boolean;
+    fromPage?: string;
+    toPage: string;
+    redirectType?: RedirectTypeCode;
+    saveQuery?: boolean;
+    country?: RedirectCondition;
+    language?: RedirectCondition;
+};
+
+export type Redirect = {
+    id: number;
+    type: RedirectKind;
+    enabled: boolean;
+    fromAllPages: boolean;
+    regularFromPage: boolean;
+    fromPage: string;
+    toPage: string;
+    redirectType: RedirectTypeCode;
+    saveQuery: boolean;
+    sortIndex: number;
+    country?: RedirectCondition;
+    language?: RedirectCondition;
+};
+
+export type RedirectListResponse = {
+    list: Redirect[];
+};
+
+export type GetRedirectsParams = {
+    type?: RedirectKind;
+};
+
+export type CreateRedirectParams = RedirectWritableFields & {
+    type: RedirectKind;
+};
+
+export type UpdateRedirectParams = Partial<CreateRedirectParams>;
+
+/**
+ * Item for PUT replace. Arrays of redirects fully replace the list for that type;
+ * omitted existing ids are deleted.
+ */
+export type ReplaceRedirectItem = Omit<CreateRedirectParams, 'type'> & {
+    id?: number;
+};

--- a/test/client/redirects.test.ts
+++ b/test/client/redirects.test.ts
@@ -1,0 +1,94 @@
+import { Redirects } from '../../src/client/redirects';
+
+import type { ApiClient } from '../../src/client/api-client';
+import type { Redirect, RedirectListResponse } from '../../src/types/redirects';
+
+describe('Redirects', () => {
+    const siteId = 42;
+    const basePath = `/sites/${ siteId }/redirects`;
+    const mockRedirect: Redirect = {
+        id: 1,
+        type: 'standard',
+        enabled: true,
+        fromAllPages: false,
+        regularFromPage: false,
+        fromPage: '/old',
+        toPage: '/new',
+        redirectType: 301,
+        saveQuery: true,
+        sortIndex: 10,
+    };
+    const mockList: RedirectListResponse = { list: [ mockRedirect ] };
+
+    let api: {
+        get: jest.Mock;
+        post: jest.Mock;
+        patch: jest.Mock;
+        put: jest.Mock;
+        delete: jest.Mock;
+    };
+    let redirects: Redirects;
+
+    beforeEach(() => {
+        api = {
+            get: jest.fn(),
+            post: jest.fn(),
+            patch: jest.fn(),
+            put: jest.fn(),
+            delete: jest.fn(),
+        };
+        redirects = new Redirects(api as unknown as ApiClient, siteId);
+    });
+
+    it('routes list/get through GET /sites/:siteId/redirects', async() => {
+        api.get
+            .mockResolvedValueOnce({ data: mockList })
+            .mockResolvedValueOnce({ data: mockList })
+            .mockResolvedValueOnce({ data: mockRedirect });
+
+        await expect(redirects.getRedirects()).resolves.toBe(mockList);
+        await expect(redirects.getRedirects({ type: 'geo' })).resolves.toBe(mockList);
+        await expect(redirects.getRedirect(1)).resolves.toBe(mockRedirect);
+
+        expect(api.get.mock.calls).toEqual([
+            [ basePath, { params: undefined } ],
+            [ basePath, { params: { type: 'geo' } } ],
+            [ `${ basePath }/1` ],
+        ]);
+    });
+
+    it('routes create/update/delete/replace with the correct method, path, and body', async() => {
+        const createBody = {
+            type: 'standard' as const,
+            fromPage: '/old',
+            toPage: '/new',
+            redirectType: 301 as const,
+            saveQuery: true,
+        };
+        const patch = { toPage: '/updated' };
+        const replaceItems = [
+            {
+                fromPage: '/old',
+                toPage: '/new',
+                redirectType: 301 as const,
+                saveQuery: true,
+            },
+        ];
+        const updated = { ...mockRedirect, toPage: '/updated' };
+
+        api.post.mockResolvedValue({ data: mockRedirect });
+        api.patch.mockResolvedValue({ data: updated });
+        api.delete.mockResolvedValue({ data: undefined });
+        api.put.mockResolvedValue({ data: mockList });
+
+        await expect(redirects.createRedirect(createBody)).resolves.toBe(mockRedirect);
+        await expect(redirects.updateRedirect(1, patch)).resolves.toBe(updated);
+        await expect(redirects.deleteRedirect(1)).resolves.toBeUndefined();
+        await expect(redirects.replaceRedirects('standard', replaceItems)).resolves.toBe(mockList);
+
+        expect(api.post).toHaveBeenCalledWith(basePath, createBody);
+        expect(api.patch).toHaveBeenCalledWith(`${ basePath }/1`, patch);
+        expect(api.delete).toHaveBeenCalledWith(`${ basePath }/1`);
+        expect(api.put).toHaveBeenCalledWith(`${ basePath }/standard`, { items: replaceItems });
+    });
+});


### PR DESCRIPTION
Expose CRUD and type-scoped replace on SiteApi.redirects with camelCase types matching the Nest redirects API.